### PR TITLE
Update R08_VNA00_J.java

### DIFF
--- a/R08_VNA00_J.java
+++ b/R08_VNA00_J.java
@@ -3,7 +3,7 @@ package cis4615_HW2;
 public class R08_VNA00_J {
 
 	final class ControlledStop implements Runnable {
-		private boolean done = false;
+		private volatile boolean done = false;
 		  
 		@Override public void run() {
 			while (!done) {


### PR DESCRIPTION
In this compliant solution, the done flag is declared volatile to ensure that writes are visible to other threads.