### PR TITLE
Update R10_THI00_J.java

### DIFF
--- a/R10_THI00_J.java
+++ b/R10_THI00_J.java
@@ -9,7 +9,7 @@ public class R10_THI00_J {
 		 
 		 public static void main(String[] args) {
 			 Foo foo = new Foo();
-			 new Thread(foo).run();
+			 new Thread(foo).start();
 		 }
 	}
 	


### PR DESCRIPTION
This compliant solution correctly uses the start() method to tell the Java runtime to start a new thread.