### PR TITLE
Update R11_TPS03_J.java

### DIFF
--- a/R11_TPS03_J.java
+++ b/R11_TPS03_J.java
@@ -3,19 +3,35 @@ package cis4615_HW2;
 public class R11_TPS03_J {
 
 	final class PoolService {
-		private final ExecutorService pool = Executors.newFixedThreadPool(10);
-		 
-		public void doSomething() {
-			pool.execute(new Task());
-		}
+		// The values have been hard-coded for brevity
+  		ExecutorService pool = new CustomThreadPoolExecutor(
+      			10, 10, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(10));
+  		// ...
 	}
-		 
-		final class Task implements Runnable {
-			@Override public void run() {
-				// ...
-				throw new NullPointerException();
-				// ...
-		    }
-		}
+ 
+	class CustomThreadPoolExecutor extends ThreadPoolExecutor {
+  		// ... Constructor ...
+  		public CustomThreadPoolExecutor(
+      			int corePoolSize, int maximumPoolSize, long keepAliveTime,
+      			TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+    		super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+  		}
+ 
+ 
+  		@Override
+  		public void afterExecute(Runnable r, Throwable t) {
+    			super.afterExecute(r, t);
+    			if (t != null) {
+      				// Exception occurred, forward to handler
+    			}
+    			// ... Perform task-specific cleanup actions
+  		}
+ 
+  		@Override
+  		public void terminated() {
+    			super.terminated();
+    			// ... Perform final clean-up actions
+  		}
+	}
 	
 }


### PR DESCRIPTION
Task-specific recovery or cleanup actions can be performed by overriding the afterExecute() hook of the java.util.concurrent.ThreadPoolExecutor class. This hook is called either when a task concludes successfully by executing all statements in its run() method or when the task halts because of an exception. Some implementations may fail to catch java.lang.Error (see Bug ID 6450211 for more information [SDN 2008]). When using this approach, substitute the executor service with a custom ThreadPoolExecutor that overrides the afterExecute() hook.